### PR TITLE
Added .q file type to be recognised as a Hive query file.

### DIFF
--- a/Syntaxes/HQL.plist
+++ b/Syntaxes/HQL.plist
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>hql</string>
+		<string>q</string>
 		<!--string>ddl</string>
 		<string>dml</string-->
 	</array>


### PR DESCRIPTION
Hive query file extension type is ".q" according to Apache SVN.
https://svn.apache.org/repos/asf/hive/trunk/ql/src/test/queries/clientpositive

By the way, thanks for creating this repo.